### PR TITLE
Add code to truncate lines too long

### DIFF
--- a/conversation_reconstruction_dataflow/ingest_revisions/dataflow_main.py
+++ b/conversation_reconstruction_dataflow/ingest_revisions/dataflow_main.py
@@ -102,7 +102,7 @@ def gzipcontent(dic):
 def truncate_content(s):
     dic = json.loads(s) 
     dic['truncated'] = False
-    if sys.get_sizeof(s) > THERESHOLD:
+    if sys.getsizeof(s) > THERESHOLD:
        l = len(dic['text'])
        dic['truncated'] = True
        dic1 = copy.deepcopy(dic)


### PR DESCRIPTION
Because some revisions are too large to be written to bigquery, revision records that are larger than a thereshold are truncated into two records, each records keeping half of the content.