### PR TITLE
Add a directory to put code for the toxic comment Kaggle competition

### DIFF
--- a/conversation_classification/kaggle/README.md
+++ b/conversation_classification/kaggle/README.md
@@ -1,0 +1,5 @@
+# Toxic Comment Classification Kaggle Challenge
+
+This directory is a place to play around with solutions for the [Toxic Comment Classification Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). The challenge was created by the Jigsaw Conversation AI team in December 2017 and the it ends in February 2018.
+
+More to come.


### PR DESCRIPTION
This change just adds a directory called under /conversation_classification to put code for playing around with solutions for Jigsaw's recent [Kaggle competition[(https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). The Perspective API is trained using a lot of internal Google machinery, so I'd like to implement some simple baselines for the Kaggle task just using TensorFlow and open source libraries. 

There's nothing but a README in the directory yet, but more to come! 