### PR TITLE
Add bag-of-words model and basic training framework

### DIFF
--- a/conversation_classification/kaggle/README.md
+++ b/conversation_classification/kaggle/README.md
@@ -1,5 +1,25 @@
 # Toxic Comment Classification Kaggle Challenge
 
-This directory is a place to play around with solutions for the [Toxic Comment Classification Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). The challenge was created by the Jigsaw Conversation AI team in December 2017 and the it ends in February 2018.
+This directory is a place to play around with solutions for the [Toxic Comment Classification Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). The challenge was created by the Jigsaw Conversation AI team in December 2017
+and the it ends in February 2018.
 
-More to come.
+These models are meant to be simple baselines created independently from the Google infrastructure.
+
+## To Run
+1. Download the training (`train.csv`) and test (`test.csv`) data from the
+[Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data).
+2. Install library dependencies:
+```shell
+pip install -r requirements.txt
+```
+
+3. Run a model on a given class (e.g. 'toxic' or 'obscene'):
+
+```shell
+python model.py --train_data=train.csv --predict_data=test.csv --y_class=toxic --model=bag_of_words
+```
+
+## Available Models
+  * `bag_of_words` - bag of words model with a learned word-embedding layer
+
+More to come!

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -1,19 +1,15 @@
-#
-# A basic Bag of Words classifier for the Toxic Comment Classification Kaggle
-# challenge, https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge
-#
-# To Run:
-#
-#   python3 model.py --train_data=train.csv --predict_data=test.csv
-#
-# Output:
-#  * writes predictions on heldout test data to TEST_OUT_PATH
-#  * writes predictions on unlabled predict data to PREDICT_OUT_PATH
-#
-# TODO:
-#  * Build a better way to view predictions
-#  * Hook up Tensorboard
-#  * Allow user to specify a model_dir
+"""
+A basic Bag of Words classifier for the Toxic Comment Classification Kaggle
+challenge, https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge
+
+To Run:
+
+python3 model.py --train_data=train.csv --predict_data=test.csv
+
+Output:
+  * writes predictions on heldout test data to TEST_OUT_PATH
+  * writes predictions on unlabled predict data to PREDICT_OUT_PATH
+"""
 
 import argparse
 import sys
@@ -28,22 +24,22 @@ FLAGS = None
 # Data Params
 MAX_LABEL = 2
 Y_CLASSES = ['toxic', 'severe_toxic','obscene','threat','insult','identity_hate']
-DATA_SEED = 48173         # Random seed used for splitting the data into train/test
-TRAIN_PERCENT = .8        # Percent of data to allocate to training
+DATA_SEED = 48173 # Random seed used for splitting the data into train/test
+TRAIN_PERCENT = .8 # Percent of data to allocate to training
 MAX_DOCUMENT_LENGTH = 500 # Max length of each comment in words
 
 # Model Params
-EMBEDDING_SIZE = 50     # Size of learned  word embedding
+EMBEDDING_SIZE = 50 # Size of learned  word embedding
 WORDS_FEATURE = 'words' # Name of the input words feature.
 
 # Training Params
-TRAIN_SEED = 9812  # Random seed used to initialize training
+TRAIN_SEED = 9812 # Random seed used to initialize training
 TRAIN_STEPS = 1000 # Number of steps to take while training
 LEARNING_RATE = 0.01
 BATCH_SIZE = 120
 
 # Output Params
-TEST_OUT_PATH = 'test_out.csv'       # Where to write results on heldout "test" data
+TEST_OUT_PATH = 'test_out.csv' # Where to write results on heldout "test" data
 PREDICT_OUT_PATH = 'predict_out.csv' # Where to write results on unlabled "predict" data
 
 class WikiData:
@@ -250,7 +246,7 @@ def main():
     tf_scores = classifier.evaluate(input_fn=test_input_fn)
 
     tf.logging.info('')
-    tf.logging.info('----------Evaluation Held-Out Data---------')
+    tf.logging.info('----------Evaluation on Held-Out Data---------')
     tf.logging.info('Accuracy (sklearn)\t: {0:f}'.format(sklearn_score))
     tf.logging.info('Accuracy (tensorflow)\t: {0:f}'.format(tf_scores['accuracy']))
     tf.logging.info('')

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -1,0 +1,287 @@
+#
+# A basic bag of words classifier for the Toxic Comment Classification Kaggle
+# challenge (https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge).
+#
+# TODO:
+#  * flag for y_class
+#  * fix batching
+#  * write way to view predictions
+#  * write out test predictions
+#  * hook up tensorboard
+#  * print probabilities of predictions
+
+import argparse
+import sys
+
+import pandas as pd
+import tensorflow as tf
+import numpy as np
+from sklearn import metrics
+
+FLAGS = None
+
+MAX_DOCUMENT_LENGTH = 1000 # TODO: should probably check that this is right
+MAX_LABEL = 2
+Y_CLASSES = ['toxic', 'severe_toxic','obscene','threat','insult','identity_hate']
+
+TRAIN_PERCENT = .8 # Percent of data to allocate to training
+DATA_SEED = 48173 # Random seed used for splitting the data into train/test
+EMBEDDING_SIZE = 50
+WORDS_FEATURE = 'words'  # Name of the input words feature.
+
+TRAIN_SEED = 9812  # Random seed used to initialize training
+TRAIN_STEPS = 100 # Number of steps to take while training
+LEARNING_RATE = 0.01
+BATCH_SIZE = 5000
+
+PREDICT_WRITE_PATH = 'predicted.csv' # place to write csv of predictions
+class WikiData:
+
+  def __init__(self, path):
+    self.data = self._load_data(path)
+    self.data['comment_text'] = self.data['comment_text'].astype(str)
+
+  def _load_data(self, path):
+      df =  pd.read_csv(path)
+
+      return df
+
+  def split(self, train_percent, y_class, seed):
+    """
+    Split divides the Wikipedia data into test and train subsets.
+
+    Args:
+      * train_percent (float): the fraction of data to use for training
+      * y_class (string): the attribute of the wiki data to predict, e.g. 'toxic'
+      * seed (integer): a seed to use to split the data in a reproducible way
+
+    Returns:
+      x_train (dataframe): the comment_text for the training data
+      y_train (dataframe): the 0 or 1 labels for the training data
+      x_test (dataframe): the comment_text for the test data
+      y_test (dataframe): the 0 or 1 labels for the test data
+    """
+
+    if y_class not in Y_CLASSES:
+      tf.logging.error('Specified y_class {0} not in list of possible classes {1}'\
+            .format(y_class, Y_CLASSES))
+      raise ValueError
+
+    if train_percent >= 1 or train_percent <= 0:
+      tf.logging.error('Specified train_percent {0} is not between 0 and 1'\
+            .format(train_percent))
+      raise ValueError
+
+    # Sample the data to create training data
+    data_train = self.data.sample(frac=train_percent, random_state=seed)
+
+    # Use remaining examples as test data
+    data_test = self.data[self.data["id"].isin(data_train["id"]) == False]
+
+    x_train = data_train['comment_text']
+    x_test = data_test['comment_text']
+    y_train = data_train[y_class]
+    y_test = data_test[y_class]
+
+    return x_train, x_test, y_train, y_test
+
+def estimator_spec_for_softmax_classification(logits, labels, mode):
+  """
+  Depending on the value of mode, different EstimatorSpec arguments are required.
+
+  For mode == ModeKeys.TRAIN: required fields are loss and train_op.
+  For mode == ModeKeys.EVAL: required field is loss.
+  For mode == ModeKeys.PREDICT: required fields are predictions.
+
+  Returns EstimatorSpec instance for softmax classification.
+  """
+  predicted_classes = tf.argmax(logits, axis=1)
+  predictions = {
+    'classes': predicted_classes,
+
+    # Add softmax_tensor to the graph. It is used for PREDICT and for training
+    # logging
+    'probabilities': tf.nn.softmax(logits, name='softmax_tensor')
+  }
+
+  # PREDICT Mode
+  if mode == tf.estimator.ModeKeys.PREDICT:
+    return tf.estimator.EstimatorSpec(mode=mode, predictions=predictions)
+
+  # Calculate Loss (for both TRAIN and EVAL modes)
+  #
+  # Note: this line with throw an exception in PREDICT mode since all the
+  # labels will be NONE.
+  loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+
+  # TRAIN Mode
+  if mode == tf.estimator.ModeKeys.TRAIN:
+    optimizer = tf.train.AdamOptimizer(learning_rate=LEARNING_RATE)
+    train_op = optimizer.minimize(loss, global_step=tf.train.get_global_step())
+
+    tensors_to_log= {'loss': loss}
+    logging_hook = tf.train.LoggingTensorHook(
+      tensors=tensors_to_log, every_n_iter=10)
+
+    return tf.estimator.EstimatorSpec(
+      mode=mode,
+      loss=loss,
+      train_op=train_op,
+      training_hooks=[logging_hook],
+      predictions={'loss': loss}
+    )
+
+  # EVAL Mode
+  eval_metric_ops = {
+    'accuracy': tf.metrics.accuracy(labels=labels, predictions=predicted_classes)
+  }
+
+  return tf.estimator.EstimatorSpec(
+    mode=mode, loss=loss, eval_metric_ops=eval_metric_ops)
+
+def bag_of_words_model(features, labels, mode):
+  """
+  A bag-of-words model. Note it disregards the word order in the text.
+
+  Returns a tf.estimator.EstimatorSpec. An EstimatorSpec fully defines the model
+  to be run by an Estimator.
+  """
+
+  bow_column = tf.feature_column.categorical_column_with_identity(
+      WORDS_FEATURE, num_buckets=n_words)
+
+  # The embedding values are initialized randomly, and are trained along with
+  # all other model parameters to minimize the training loss.
+  bow_embedding_column = tf.feature_column.embedding_column(
+      bow_column, dimension=EMBEDDING_SIZE)
+
+  bow = tf.feature_column.input_layer(
+      features,
+      feature_columns=[bow_embedding_column])
+
+  logits = tf.layers.dense(bow, MAX_LABEL, activation=None)
+
+  return estimator_spec_for_softmax_classification(
+      logits=logits, labels=labels, mode=mode)
+
+def main():
+    global n_words
+
+    tf.logging.set_verbosity(tf.logging.INFO)
+
+    if FLAGS.verbose:
+      tf.logging.info('Running in verbose mode')
+      tf.logging.set_verbosity(tf.logging.DEBUG)
+
+    # Load data
+    tf.logging.debug('Loading data {}'.format(FLAGS.train_data))
+    data = WikiData(FLAGS.train_data)
+
+    # Split data
+    x_train_text, x_test_text, y_train, y_test \
+      = data.split(TRAIN_PERCENT, 'toxic', DATA_SEED)
+
+    # Process data
+    vocab_processor = tf.contrib.learn.preprocessing.VocabularyProcessor(
+      MAX_DOCUMENT_LENGTH)
+
+    x_train = np.array(list(vocab_processor.fit_transform(x_train_text)))
+    x_test = np.array(list(vocab_processor.fit_transform(x_test_text)))
+    y_train = np.array(y_train)
+    y_test = np.array(y_test)
+
+    n_words = len(vocab_processor.vocabulary_)
+    tf.logging.info('Total words: %d' % n_words)
+
+    # Build model
+
+    # Note: model_fn is of type tf.estimator.EstimatorSpec
+    model_fn = bag_of_words_model
+
+    # Subtract 1 because VocabularyProcessor outputs a word-id matrix where word
+    # ids start from 1 and 0 means 'no word'. But categorical_column_with_identity
+    # assumes 0-based count and uses -1 for missing word.
+    x_train -= 1
+    x_test -= 1
+
+    classifier = tf.estimator.Estimator(
+      model_fn=model_fn,
+      config=tf.contrib.learn.RunConfig(
+        tf_random_seed=TRAIN_SEED,
+      ),
+      model_dir="/tmp/kaggle_model")
+
+    # Train
+    train_input_fn = tf.estimator.inputs.numpy_input_fn(
+      x={WORDS_FEATURE: x_train},
+      y=y_train,
+      batch_size=BATCH_SIZE,
+      num_epochs=None,
+      shuffle=True)
+
+    classifier.train(
+      input_fn=train_input_fn,
+      steps=TRAIN_STEPS)
+
+    # Predict on held-out data
+    test_input_fn = tf.estimator.inputs.numpy_input_fn(
+      x={WORDS_FEATURE: x_test},
+      y=y_test,
+      num_epochs=1,
+      shuffle=False)
+
+    # TODO: figure out why we can only read predictions once
+    test_predictions = classifier.predict(input_fn=test_input_fn)
+    y_test_predicted = np.array(list(p['classes'] for p in test_predictions))
+
+    data_test = x_train_text
+    data_test[FLAGS.y_class] = y_test
+    data_test[FLAGS.y_class + '_predicted'] = y_test_predicted
+
+    tf.logging.info("Writing held-out test predictions to {}"
+                    .format(TEST_WRITE_PATH))
+    data_predict.to_csv(TEST_WRITE_PATH)
+
+    # Score with sklearn
+    sklearn_score = metrics.accuracy_score(y_test, y_test_predicted)
+
+    # Score with TensorFlow
+    tf_scores = classifier.evaluate(input_fn=test_input_fn)
+
+    tf.logging.info('')
+    tf.logging.info('Accuracy (sklearn)\t: {0:f}'.format(sklearn_score))
+    tf.logging.info('Accuracy (tensorflow)\t: {0:f}'.format(tf_scores['accuracy']))
+
+    # Predict on prediction data (no labels)
+    tf.logging.info('')
+    tf.logging.info('Generating predictions for {}'.format(FLAGS.predict_data))
+
+    data_predict = WikiData(FLAGS.predict_data).data
+    x_predict = np.array(list(
+      vocab_processor.fit_transform(data_predict['comment_text'])))
+
+    predict_input_fn = tf.estimator.inputs.numpy_input_fn(
+      x={WORDS_FEATURE: x_predict},
+      num_epochs=1,
+      shuffle=False)
+
+    predict_predictions = classifier.predict(input_fn=predict_input_fn)
+    y_predicted = np.array(list(p['classes'] for p in predict_predictions))
+
+    data_predict['y_predicted'] = y_predicted
+    tf.logging.info("Writing predictions to {}".format(PREDICT_WRITE_PATH))
+    data_predict.to_csv(PREDICT_WRITE_PATH)
+
+if __name__ == '__main__':
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--verbose', help='Run in verbose mode.', action='store_true')
+  parser.add_argument(
+      "--train_data", type=str, default="", help="Path to the training data.")
+  parser.add_argument(
+      "--predict_data", type=str, default="", help="Path to the prediction data.")
+
+  FLAGS, unparsed = parser.parse_known_args()
+
+  main()

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -17,7 +17,8 @@ import sys
 import pandas as pd
 import tensorflow as tf
 import numpy as np
-from sklearn import metrics
+import sklearn as sk
+from sklearn.model_selection import train_test_split
 
 FLAGS = None
 
@@ -80,18 +81,13 @@ class WikiData:
             .format(train_percent))
       raise ValueError
 
-    tf.logging.info("Training on class '{}'".format(y_class))
+    tf.logging.info("Training on class: '{}'".format(y_class))
+    tf.logging.info("Training data split: {}".format(train_percent))
 
-    # Sample the data to create training data
-    data_train = self.data.sample(frac=train_percent, random_state=seed)
-
-    # Use remaining examples as test data
-    data_test = self.data[self.data["id"].isin(data_train["id"]) == False]
-
-    x_train = data_train['comment_text']
-    x_test = data_test['comment_text']
-    y_train = data_train[y_class]
-    y_test = data_test[y_class]
+    X = self.data['comment_text']
+    y = self.data[y_class]
+    x_train, x_test, y_train, y_test = train_test_split(
+      X, y, test_size=1-train_percent, random_state=seed)
 
     return x_train, x_test, y_train, y_test
 
@@ -249,7 +245,7 @@ def main():
     test_out.to_csv(TEST_OUT_PATH)
 
     # Score with sklearn and TensorFlow (hopefully they're the same!)
-    sklearn_score = metrics.accuracy_score(y_test, test_out['y_predicted'])
+    sklearn_score = sk.metrics.accuracy_score(y_test, test_out['y_predicted'])
     tf_scores = classifier.evaluate(input_fn=test_input_fn)
 
     tf.logging.info('')

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -179,7 +179,7 @@ def main():
     data = WikiData(FLAGS.train_data)
 
     x_train_text, x_test_text, y_train, y_test \
-      = data.split(TRAIN_PERCENT, 'toxic', DATA_SEED)
+      = data.split(TRAIN_PERCENT, FLAGS.y_class, DATA_SEED)
 
     # Process data
     vocab_processor = tf.contrib.learn.preprocessing.VocabularyProcessor(

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -4,7 +4,7 @@ challenge, https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challeng
 
 To Run:
 
-python3 model.py --train_data=train.csv --predict_data=test.csv --y_class=toxic
+python model.py --train_data=train.csv --predict_data=test.csv --y_class=toxic
 
 Output:
   * writes predictions on heldout test data to TEST_OUT_PATH
@@ -40,8 +40,8 @@ LEARNING_RATE = 0.01
 BATCH_SIZE = 120
 
 # Output Params
-TEST_OUT_PATH = 'test_out.csv' # Where to write results on heldout "test" data
-PREDICT_OUT_PATH = 'predict_out.csv' # Where to write results on unlabled "predict" data
+TEST_OUT_PATH = 'test_out.csv' # Where to write results on heldout data
+PREDICT_OUT_PATH = 'predict_out.csv' # Where to write results on unlabled data
 
 class WikiData:
 

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -4,7 +4,7 @@ challenge, https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challeng
 
 To Run:
 
-python3 model.py --train_data=train.csv --predict_data=test.csv
+python3 model.py --train_data=train.csv --predict_data=test.csv --y_class=toxic
 
 Output:
   * writes predictions on heldout test data to TEST_OUT_PATH
@@ -221,7 +221,7 @@ def main():
 
     classifier.train(input_fn=train_input_fn, steps=TRAIN_STEPS)
 
-    # Predict on test data (i.e. held-out data)
+    # Predict on held-out test data
     test_input_fn = tf.estimator.inputs.numpy_input_fn(
       x={WORDS_FEATURE: x_test},
       y=y_test,
@@ -238,6 +238,7 @@ def main():
     test_out['comment_text'] = x_train_text
     test_out['y_true'] = y_test
 
+    # Write out predictions and probabilities for test data
     tf.logging.info("Writing test predictions to {}".format(TEST_OUT_PATH))
     test_out.to_csv(TEST_OUT_PATH)
 
@@ -275,6 +276,7 @@ def main():
     )
     unlabeled_out['comment_text'] = data_unlabeled['comment_text']
 
+    # Write out predictions and probabilities for unlabled "predict" data
     tf.logging.info("Writing predictions to {}".format(PREDICT_OUT_PATH))
     unlabeled_out.to_csv(PREDICT_OUT_PATH)
 

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -31,6 +31,7 @@ MAX_DOCUMENT_LENGTH = 500 # Max length of each comment in words
 # Model Params
 EMBEDDING_SIZE = 50 # Size of learned  word embedding
 WORDS_FEATURE = 'words' # Name of the input words feature.
+MODEL_LIST = ['bag_of_words']
 
 # Training Params
 TRAIN_SEED = 9812 # Random seed used to initialize training
@@ -194,7 +195,12 @@ def main():
     tf.logging.info('Total words: %d' % n_words)
 
     # Build model
-    model_fn = bag_of_words_model
+    if FLAGS.model == 'bag_of_words':
+      model_fn = bag_of_words_model
+    else:
+      tf.logging.error("Unknown specified model '{}', must be one of {}"
+                       .format(FLAGS.model, MODEL_LIST))
+      raise ValueError
 
     # Subtract 1 because VocabularyProcessor outputs a word-id matrix where word
     # ids start from 1 and 0 means 'no word'. But categorical_column_with_identity
@@ -292,6 +298,9 @@ if __name__ == '__main__':
   parser.add_argument(
       "--y_class", type=str, default="toxic",
     help="Class to train model against, one of {}".format(Y_CLASSES))
+  parser.add_argument(
+      "--model", type=str, default="bag_of_words",
+    help="The model to train, one of {}".format(MODEL_LIST))
 
   FLAGS, unparsed = parser.parse_known_args()
 

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -197,16 +197,16 @@ def main():
     # Build model
     if FLAGS.model == 'bag_of_words':
       model_fn = bag_of_words_model
+
+      # Subtract 1 because VocabularyProcessor outputs a word-id matrix where word
+      # ids start from 1 and 0 means 'no word'. But categorical_column_with_identity
+      # assumes 0-based count and uses -1 for missing word.
+      x_train -= 1
+      x_test -= 1
     else:
       tf.logging.error("Unknown specified model '{}', must be one of {}"
                        .format(FLAGS.model, MODEL_LIST))
       raise ValueError
-
-    # Subtract 1 because VocabularyProcessor outputs a word-id matrix where word
-    # ids start from 1 and 0 means 'no word'. But categorical_column_with_identity
-    # assumes 0-based count and uses -1 for missing word.
-    x_train -= 1
-    x_test -= 1
 
     classifier = tf.estimator.Estimator(
       model_fn=model_fn,

--- a/conversation_classification/kaggle/requirements.txt
+++ b/conversation_classification/kaggle/requirements.txt
@@ -1,0 +1,16 @@
+bleach==1.5.0
+enum34==1.1.6
+html5lib==0.9999999
+Markdown==2.6.10
+numpy==1.13.3
+pandas==0.22.0
+protobuf==3.5.1
+python-dateutil==2.6.1
+pytz==2017.3
+scikit-learn==0.19.1
+scipy==1.0.0
+six==1.11.0
+sklearn==0.0
+tensorflow==1.4.1
+tensorflow-tensorboard==0.4.0rc3
+Werkzeug==0.14.1


### PR DESCRIPTION
This change adds a basic framework for training a model in TensorFlow for the toxicity Kaggle competition. 

### What the script does
* loads the training data for the toxicity competition (you'll need to download it from [here](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data) first)
* splits it into a training and held-out test set
* trains a model
* evaluates the model on the held-out data
* makes predictions for the held-out data and the unlabeled test data and writes them to a file

### What the script does not do
* Search over the parameter space
* Save the model
* I make no claims about good accuracy, I haven't optimized for that yet

The model here is just a simple bag of words model with a learned word embedding layer. My plan is to use this code to play around with different simple baselines for the Kaggle competition that are trained separately from the Google ML training infrastructure. _(And to use that task as a way to learn TensorFlow.)_

### To Run

1. Download the training (`train.csv`) and test (`test.csv`) data from the
[Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data).
2. Install library dependencies:
```shell
pip install -r requirements.txt
```

3. Run a model on a given class (e.g. 'toxic' or 'obscene'):

```shell
python model.py --train_data=train.csv --predict_data=test.csv --y_class=toxic --model=bag_of_words
```

### Next Steps
I made issues [here](https://github.com/conversationai/wikidetox/issues?q=is%3Aissue+is%3Aopen+label%3Akaggle) for the features I'd like to add. Let me know if you want me to include any or them in this PR. 
