### PR TITLE
Add CNN model

### DIFF
--- a/conversation_classification/kaggle/.gitignore
+++ b/conversation_classification/kaggle/.gitignore
@@ -1,1 +1,2 @@
 *.csv
+saved_models/*

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -387,7 +387,7 @@ def main():
         dtype=tf.int64, shape=MAX_DOCUMENT_LENGTH)
     }
     serving_input_fn = tf.estimator.export.build_parsing_serving_input_receiver_fn(feature_spec)
-    dir_path = 'saved_model'
+    dir_path = 'saved_models'
 
     classifier.export_savedmodel(dir_path, serving_input_fn)
 

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -36,7 +36,7 @@ FILTER_SHAPE2 = [WINDOW_SIZE, N_FILTERS]
 POOLING_WINDOW = 4
 POOLING_STRIDE = 2
 WORDS_FEATURE = 'words' # Name of the input words feature.
-MODEL_LIST = ['bag_of_words']
+MODEL_LIST = ['bag_of_words', 'cnn'] # Possible models
 
 # Training Params
 TRAIN_SEED = 9812 # Random seed used to initialize training

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -1,6 +1,6 @@
 """
-A basic Bag of Words classifier for the Toxic Comment Classification Kaggle
-challenge, https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge
+Classifiers for the Toxic Comment Classification Kaggle challenge,
+https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge
 
 To Run:
 

--- a/conversation_classification/kaggle/model.py
+++ b/conversation_classification/kaggle/model.py
@@ -384,7 +384,7 @@ def main():
     # Export the model
     feature_spec = {
       WORDS_FEATURE: tf.FixedLenFeature(
-        dtype=tf.int64, shape=[1, MAX_DOCUMENT_LENGTH])
+        dtype=tf.int64, shape=MAX_DOCUMENT_LENGTH)
     }
     serving_input_fn = tf.estimator.export.build_parsing_serving_input_receiver_fn(feature_spec)
     dir_path = 'saved_model'


### PR DESCRIPTION
This change adds a 2-layer CNN as a possible model that is almost completely copied from [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/text_classification_cnn.py). It does see to work though. 

To Run: 
```
 python model.py --train_data=train.csv --predict_data=test.csv \
 --y_class=toxic --train_steps=10 --model=cnn
```