### PR TITLE
spacing, unused vars, and minor pylint cleanup

### DIFF
--- a/wikiconv/conversation_reconstruction/constructor_tester.py
+++ b/wikiconv/conversation_reconstruction/constructor_tester.py
@@ -20,7 +20,9 @@ This is a testing framework to test the functionality of conversation constructo
 Run with default setting:
   python conversation_tester.py
 
-The conversation constructor has the functionality of saving the intermediate page state in order to load and continue on it. This should provide a list of revisions that you want to test the loading functionality on.
+The conversation constructor has the functionality of saving the intermediate
+page state in order to load and continue on it. This should provide a list of
+revisions that you want to test the loading functionality on.
 
 """
 
@@ -66,7 +68,7 @@ def merge(ps1, ps2):
      ret_p['conversation_id'] = ret_p['conversation_id']
      ret_p['authors'] = ret_p['authors']
      for i in extra_ids:
-         ret_p['conversation_id'][i] = conv_ids[i] 
+         ret_p['conversation_id'][i] = conv_ids[i]
          ret_p['authors'][i] = auth[i]
      ret_p['conversation_id'] = ret_p['conversation_id']
      ret_p['authors'] = ret_p['authors']
@@ -79,11 +81,8 @@ class TestReconstruction(unittest.TestCase):
         logging.info("TEST LOG: testing starts on page %s" % str(p))
         processor = Conversation_Constructor()
         cnt = 0
-        last_revision = "None"
         page_state = None
         second_last_page_state = None
-        last_revision_to_save = None
-        last_loading = 0
         latest_content = ""
         ans = []
         if not(p == "dummy_test"):
@@ -94,27 +93,26 @@ class TestReconstruction(unittest.TestCase):
           last_week = -1
           for ind, line in enumerate(f):
                revision = json.loads(line)
-               last_revision = revision['rev_id']
                week = datetime.datetime.strptime(revision['timestamp'], TIMESTAMP_FORMAT).isocalendar()[1]
                year = datetime.datetime.strptime(revision['timestamp'], TIMESTAMP_FORMAT).year
                cnt += 1
-               if ((cnt % LOG_INTERVAL == 0 and cnt) \
-                   or (last_week >= 0 and last_week != week))\
-                  and not(page_state == None):
+               if (((cnt % LOG_INTERVAL == 0 and cnt)
+                    or (last_week >= 0 and last_week != week))
+                   and not(page_state == None)):
                  # Reload after every LOG_INTERVAL revisions to keep the low memory
                  # usage.
                   memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
                   logging.info("MENMORY BEFORE RELOADING : %d KB" % memory_usage)
                   processor = Conversation_Constructor()
                   #second_last_page_state = copy.deepcopy(page_state)
-                  processor.load(page_state['deleted_comments'])
-                  del page_state['deleted_comments']
-                  page_state['deleted_comments'] = []
+                  processor.load(page_state['deleted_comments'])  # pylint: disable=E1136
+                  del page_state['deleted_comments']  # pylint: disable=E1136,E1138
+                  page_state['deleted_comments'] = []  # pylint: disable=E1136,E1138,E1137
                   print(year, week)
                   memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
                   logging.info("MENMORY AFTER RELOADING : %d KB" % memory_usage)
 
-               if revision['rev_id'] in LOADING_TEST: 
+               if revision['rev_id'] in LOADING_TEST:
                   if second_last_page_state:
                      page_state_test = merge(page_state, second_last_page_state)
                   else:


### PR DESCRIPTION
* Removed unused vars from conversation_tester.py
* Make code easier to read without wrapping
* Suppress some not relevant pylint warnings. 
* Make memory warning info a warning message, not an info message