### PR TITLE
Add hooks to integrate pip and bazel together.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,23 @@
 # Bazel workspace file.
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "io_bazel_rules_python",
+    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+)
+
+load("@io_bazel_rules_python//python:pip.bzl", "pip_import")
+
+# This rule translates the specified requirements.txt into
+# @wikidetox_requirements//:requirements.bzl, which itself exposes a pip_install method.
+pip_import(
+    name = "wikidetox_requirements",
+    requirements = "//:requirements.txt",
+)
+
+# Load the pip_install symbol for my_deps, and create the dependencies'
+# repositories.
+load("@wikidetox_requirements//:requirements.bzl", "pip_install")
+
+pip_install()

--- a/antidox/BUILD
+++ b/antidox/BUILD
@@ -1,0 +1,15 @@
+load("@wikidetox_requirements//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "wikiwatcher",
+    srcs = ["wikiwatcher.py"],
+    deps = [
+        requirement("sseclient"),
+    ],
+)
+
+py_test(
+    name = "wikiwatcher_test",
+    srcs = ["wikiwatcher_test.py"],
+    deps = [":wikiwatcher"],
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client==1.7.9
+mock==3.0.5
+pandas==v0.23.4
+sseclient==0.0.24


### PR DESCRIPTION
This allows one unified requirements file, but explicit declaration
of packages needed for each target, which is a big improvement.
This only hooks in one target, will follow up with the remainder.